### PR TITLE
version compatibility updates

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,33 +1,240 @@
 name: Test
 
-on: [push]
+on:
+  push:
+    branches:
+      - main
+      - develop*
+  pull_request:
+    branches:
+      - main
+      - develop*
+  schedule:
+    - cron: '0 6 * * *'
 
 jobs:
   test:
+    name: Test compiler
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-22.04, ubuntu-20.04, ubuntu-18.04, macos-12, macos-11, windows-2022, windows-2019]
         compiler: [gcc]
-        version: [11, 10, 9, 8]
-
+        version: [12, 11, 10, 9, 8, 7, 6, 5]
     steps:
+
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Fortran
+        continue-on-error: true
         id: setup-fortran
         uses: ./
         with:
           compiler: ${{ matrix.compiler }}
           version: ${{ matrix.version }}
 
-      - name: Check Fortran compiler
-        run: |
-          ${{ env.FC }} --version
-          ${{ env.CC }} --version
+      - name: Check compiler version
+        if: steps.setup-fortran.outcome == 'success'
         shell: bash
         env:
           FC: ${{ steps.setup-fortran.outputs.fc }}
           CC: ${{ steps.setup-fortran.outputs.cc }}
+        run: |
+          fcv=$(${{ env.FC }} --version | head -n 1)
+          ccv=$(${{ env.CC }} --version | head -n 1)
+          
+          echo $fcv
+          echo $ccv
+          
+          fcv=$(echo "${fcv##*)}" | xargs)
+          ccv=$(echo "${ccv##*)}" | xargs)
+          
+          [[ $fcv == ${{ matrix.version }}* ]] || (echo "unexpected Fortran compiler version: $fcv"; exit 1)
+          [[ $ccv == ${{ matrix.version }}* ]] || (echo "unexpected C compiler version: $ccv"; exit 1)
+
+      - name: Test compile program (bash)
+        if: steps.setup-fortran.outcome == 'success'
+        shell: bash
+        env:
+          FC: ${{ steps.setup-fortran.outputs.fc }}
+          CC: ${{ steps.setup-fortran.outputs.cc }}
+        run: |
+          ${{ env.FC }} -o hw hw.f90
+          output=$(./hw '2>&1')
+          [[ "$output" == *"hello world"* ]] && echo "$output" || (echo "Unexpected output: $output"; exit 1)
+
+      - name: Test compile program (Powershell Core)
+        if: steps.setup-fortran.outcome == 'success' && runner.os == 'Windows'
+        shell: pwsh
+        env:
+          FC: ${{ steps.setup-fortran.outputs.fc }}
+          CC: ${{ steps.setup-fortran.outputs.cc }}
+        run: |
+          rm hw.exe
+          ${{ env.FC }} -o hw.exe hw.f90 
+          $output=$(& ".\hw.exe")
+          if ($output -match "hello world") {
+              write-output $output
+          } else {
+              write-output "unexpected output: $output"
+              exit 1
+          }
+      
+      - name: Test compile program (Powershell Desktop)
+        if: steps.setup-fortran.outcome == 'success' && runner.os == 'Windows'
+        shell: powershell
+        env:
+          FC: ${{ steps.setup-fortran.outputs.fc }}
+          CC: ${{ steps.setup-fortran.outputs.cc }}
+        run: |
+          rm hw.exe
+          ${{ env.FC }} -o hw.exe hw.f90 
+          $output=$(& ".\hw.exe")
+          if ($output -match "hello world") {
+              write-output $output
+          } else {
+              write-output "unexpected output: $output"
+              exit 1
+          }
+
+      - name: Test compile program (cmd)
+        if: steps.setup-fortran.outcome == 'success' && runner.os == 'Windows'
+        shell: cmd
+        env:
+          FC: ${{ steps.setup-fortran.outputs.fc }}
+          CC: ${{ steps.setup-fortran.outputs.cc }}
+        run: |
+          del hw.exe
+          ${{ env.FC }} -o hw.exe hw.f90 
+          for /f "tokens=* usebackq" %%f in (`.\hw.exe`) do @set "OUTPUT=%%f"
+          if "%OUTPUT%"=="hello world" (
+            echo %OUTPUT%
+          ) else (
+            echo unexpected output: %OUTPUT%
+            exit 1
+          )
+
+      - name: Create compatibility report
+        shell: bash
+        run: |
+          if [[ "${{ steps.setup-fortran.outcome }}" == "success" ]]; then
+            support="&check;"
+          else
+            support=""
+          fi
+          
+          mkdir compat
+          prefix="${{ matrix.os }},${{ matrix.compiler }},${{ matrix.version }}"
+          echo "$prefix,$support" >> "compat/${prefix//,/_}.csv"
+
+      - name: Upload compatibility report
+        uses: actions/upload-artifact@v3
+        with:
+          name: compat
+          path: compat/*.csv
+
+  compat:
+    name: Report compatibility
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.9
+
+      - name: Install packages
+        run: |
+          pip install tabulate pandas
+
+      - name: Download reports
+        uses: actions/download-artifact@v3
+        with:
+          name: compat
+          path: compat
+
+      - name: Concatenate reports
+        run: |
+          echo "runner,compiler,version,support" > compat_long.csv
+          cat compat/*.csv >> compat_long.csv
+
+      - name: Make wide CSV and MD table
+        id: merge-reports
+        shell: python
+        run: |
+          import pandas as pd
+          df = pd.read_csv("compat_long.csv")
+          df = pd.pivot(df, index="runner", columns="version", values="support")
+          df = df.sort_values(by=["runner"])
+          df.to_csv("compat.csv")
+          with open("compat.md", "w") as file:
+            file.write(df.to_markdown().replace("nan", ""))
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: compat
+          path: |
+            compat.csv
+            compat.md
+
+      - name: Check for changes
+        id: diff
+        run: |
+          if ! [ -f compat.csv ]; then
+            echo "diff=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          diff=$(git diff compat.csv)
+          if [[ $diff == "" ]]; then
+            echo "No changes found"
+            echo "diff=false" >> $GITHUB_OUTPUT
+          else
+            echo "Changes found:"
+            echo "$diff"
+            echo "diff=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Update README
+        if: steps.diff.outputs.diff == 'true'
+        shell: python
+        run: |
+          import re
+          from pathlib import Path
+          readme_path = Path("README.md")
+          readme = readme_path.open().read()
+          with open("compat.md", "r") as compat:
+            table = ''.join(compat.readlines())
+            r = re.compile(r'<!\-\- compat starts \-\->.*<!\-\- compat ends \-\->', re.DOTALL)
+            chunk = '<!-- compat starts -->{}<!-- compat ends -->'.format('\n{}\n'.format(table))
+            readme_path.open('w').write(r.sub(chunk, readme))
+
+      - name: Print README diff
+        if: steps.diff.outputs.diff == 'true'
+        run: |
+          git diff README.md
+
+      - name: Create pull request
+        if: steps.diff.outputs.diff == 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          
+          now=$(date +'%Y-%m-%dT%H-%M-%S')
+          updated_branch="compat_$now"
+          default_branch="${{ github.event.repository.default_branch }}"
+          
+          git switch -c "$updated_branch"
+          git add compat.csv README.md
+          git commit -m "Update compatibility matrix"
+          git push -u origin "$updated_branch"
+          gh pr create -B "$default_branch" -H "$updated_branch" --title "Update compatibility matrix" --body-file compat.md

--- a/README.md
+++ b/README.md
@@ -1,11 +1,13 @@
 # Setup Fortran
 
-GitHub action to setup a Fortran compiler on the supported runners.
+[![Test](https://github.com/awvwgk/setup-fortran/actions/workflows/test.yml/badge.svg)](https://github.com/awvwgk/setup-fortran/actions/workflows/test.yml)
+
+Action to setup a Fortran compiler.
 
 
 ## Usage
 
-This action allows to setup Fortran compilers on all Ubuntu, MacOS and Windows.
+This action allows setting up Fortran compilers on Ubuntu, MacOS and Windows runners.
 
 ```yaml
 jobs:
@@ -31,11 +33,26 @@ jobs:
 
 ## Options
 
-- *compiler*: Compiler toolchain to setup,
-  available options are *gcc*.
+- *compiler*: Compiler toolchain to setup, available options are *gcc*
+- *version*: Version of the compiler toolchain, available options for *gcc* are *5-12*
 
-- *version*: Version of the compiler toolchain,
-  available options for *gcc* are 11, 10, 9, 8, 7 (Ubuntu and MacOS), 6 (MacOS), 5 (MacOS)
+
+## Runner compatibility
+
+<!-- compat starts -->
+
+|                               | 5       | 6       | 7       | 8       | 9       | 10      | 11      | 12      |
+|-------------------------------|---------|---------|---------|---------|---------|---------|---------|---------|
+| ubuntu-22.04                  |         |         |         |         | &check; | &check; | &check; | &check; |
+| ubuntu-20.04 (ubuntu-latest)  |         |         | &check; | &check; | &check; | &check; | &check; |         |
+| ubuntu-18.04                  | &check; | &check; | &check; | &check; | &check; | &check; | &check; |         |
+| macos-12                      |         | &check; | &check; | &check; | &check; | &check; | &check; | &check; |
+| macos-11 (macos-latest)       |         | &check; | &check; | &check; | &check; | &check; | &check; | &check; |
+| macos-10.15                   |         | &check; | &check; | &check; | &check; | &check; | &check; | &check; |
+| windows-2022 (windows-latest) |         |         |         | &check; | &check; | &check; | &check; | &check; |
+| windows-2019                  |         |         |         | &check; | &check; | &check; | &check; | &check; |
+
+<!-- compat ends -->
 
 
 ## License

--- a/action.yml
+++ b/action.yml
@@ -19,10 +19,56 @@ runs:
   using: "composite"
   steps:
     - id: setup
-      run: |
-        action_path=$(echo '/${{ github.action_path }}' | sed -e 's/\\/\//g' -e 's/://')
-        "$action_path/setup-fortran.sh"
+      name: Setup toolchain
       shell: bash
       env:
         COMPILER: ${{ inputs.compiler }}
         VERSION: ${{ inputs.version }}
+      run: |
+        action_path=$(echo '/${{ github.action_path }}' | sed -e 's/\\/\//g' -e 's/://')
+        source "$action_path/setup-fortran.sh"
+        
+        compiler=${COMPILER:-gcc}
+        platform=$(uname -s | tr '[:upper:]' '[:lower:]')
+
+        case $compiler in
+          gcc)
+            version=${VERSION:-11}
+            ;;
+          *)
+            exit 1
+            ;;
+        esac
+
+        case $platform in
+          linux*)
+            install_gcc_apt
+            ;;
+          darwin*)
+            install_gcc_brew
+            ;;
+          mingw*)
+            install_gcc_choco
+            ;;
+          msys*)
+            install_gcc_choco
+            ;;
+          cygwin*)
+            install_gcc_choco
+            ;;
+          *)
+            echo "Unsupported platform: $platform"
+            exit 1
+            ;;
+        esac
+
+        which "${FC}"
+        which "${CC}"
+  
+        # set outputs
+        echo "fc=${FC}" >> $GITHUB_OUTPUT
+        echo "cc=${CC}" >> $GITHUB_OUTPUT
+        
+        # persist environment variables
+        echo "FC=${FC}" >> $GITHUB_ENV
+        echo "CC=${CC}" >> $GITHUB_ENV

--- a/hw.f90
+++ b/hw.f90
@@ -1,0 +1,3 @@
+program hello
+  print *, "hello world"
+end program hello

--- a/setup-fortran.sh
+++ b/setup-fortran.sh
@@ -5,9 +5,23 @@ set -ex
 install_gcc_brew()
 {
   brew install gcc@${version}
-  ln -s /usr/local/bin/gfortran-${version} /usr/local/bin/gfortran
-  ln -s /usr/local/bin/gcc-${version} /usr/local/bin/gcc
-  ln -s /usr/local/bin/g++-${version} /usr/local/bin/g++
+  ln -fs /usr/local/bin/gfortran-${version} /usr/local/bin/gfortran
+  ln -fs /usr/local/bin/gcc-${version} /usr/local/bin/gcc
+  ln -fs /usr/local/bin/g++-${version} /usr/local/bin/g++
+
+  # link lib dir for previous GCC versions to avoid missing .dylib issues
+  for (( i=12; i>4; i-- ))
+  do
+    gcc_lib_path="/usr/local/opt/gcc/lib/gcc/$i"
+    if [ -d $gcc_lib_path ]; then
+      echo "found $gcc_lib_path"
+      for (( j=$i; j>4; j-- ))
+      do
+        ln -fs /usr/local/opt/gcc/lib/gcc/$i /usr/local/opt/gcc/lib/gcc/$j
+      done
+      break
+    fi
+  done
 
   export FC="gfortran"
   export CC="gcc"
@@ -29,10 +43,50 @@ install_gcc_apt()
   export CXX="g++"
 }
 
+install_gcc_choco()
+{
+  case $version in
+    12)
+      choco install mingw --version 12.2.0 --force
+      ;;
+    11)
+      choco install mingw --version 11.2.0 --force
+      ;;
+    10)
+      choco install mingw --version 10.3.0 --force
+      ;;
+    9)
+      choco install mingw --version 9.4.0 --force
+      ;;
+    8)
+      choco install mingw --version 8.5.0 --force
+      ;;
+    *)
+      echo "Unsupported version: $version (choose 8-12)"
+      exit 1
+      ;;
+  esac
+
+  export FC="gfortran"
+  export CC="gcc"
+  export CXX="g++"
+
+  # missing DLL can cause successfully compiled executables to fail at runtime
+  FCDIR=/c/ProgramData/Chocolatey/bin
+  LNDIR=/c/ProgramData/Chocolatey/lib/mingw/tools/install/mingw64/bin
+  if [ -d "$FCDIR" ] && [ -f "$LNDIR/libgfortran-5.dll" ] && [ ! -f "$FCDIR/libgfortran-5.dll" ]; then
+      ln -s "$LNDIR/libgfortran-5.dll" "$FCDIR/libgfortran-5.dll"
+  fi
+}
+
 install_gcc_winlibs()
 {
   repo="https://github.com/brechtsanders/winlibs_mingw/releases/download"
   case $version in
+    12)
+      tag="12.2.0-14.0.6-10.0.0-ucrt-r2"
+      zip="winlibs-x86_64-posix-seh-gcc-12.2.0-mingw-w64ucrt-10.0.0-r2.zip"
+      ;;
     11)
       tag="11.2.0-12.0.1-9.0.0-r1"
       zip="winlibs-x86_64-posix-seh-gcc-11.2.0-mingw-w64-9.0.0-r1.zip"
@@ -50,6 +104,7 @@ install_gcc_winlibs()
       zip="winlibs-x86_64-posix-seh-gcc-8.5.0-mingw-w64-9.0.0-r1.zip"
       ;;
     *)
+      echo "Unsupported version: $version (choose 8-12)"
       exit 1
       ;;
   esac
@@ -57,49 +112,17 @@ install_gcc_winlibs()
   if command -v curl > /dev/null 2>&1; then
     fetch="curl -L"
   elif command -v wget > /dev/null 2>&1; then
-    FETCH="wget -O -"
+    fetch="wget -O -"
   else
     echo "No download mechanism found. Install curl or wget first."
     exit 1
   fi
 
   $fetch "$repo/$tag/$zip" > gcc.zip
-  unzip -qo gcc.zip -d /
+
+  unzip -qo gcc.zip "mingw64/bin/*" -d /
 
   export FC="gfortran"
   export CC="gcc"
   export CXX="g++"
 }
-
-compiler=${COMPILER:-gcc}
-platform=$(uname -s)
-
-case $compiler in
-  gcc)
-    version=${VERSION:-9}
-    ;;
-  *)
-    exit 1
-    ;;
-esac
-
-case $platform in
-  Linux*)
-    install_gcc_apt
-    ;;
-  Darwin*)
-    install_gcc_brew
-    ;;
-  MINGW*)
-    install_gcc_winlibs
-    ;;
-  *)
-    exit 1
-    ;;
-esac
-
-which "${FC}"
-which "${CC}"
-
-echo "::set-output name=fc::${FC}"
-echo "::set-output name=cc::${CC}"


### PR DESCRIPTION
* expand test matrix
* add version compatibility table to README
* replace set-output with GITHUB_OUTPUT file (pending deprecation)
* add tests for pwsh, powershell and cmd on Windows
* add cases for uname on Windows: msys* and cygwin*
* use Chocolatey to install mingw on Windows
* link to libgfortran-5.dll on Windows
* link to older version lib paths on Mac
* store runner compatibility in CSV file
* autodetect runner compatiblity changes
* autocreate PR to update README on compat changes